### PR TITLE
Fixed include path

### DIFF
--- a/DBAWebpImageDecoder.m
+++ b/DBAWebpImageDecoder.m
@@ -1,5 +1,5 @@
 #import "DBAWebpImageDecoder.h"
-#include "webp/decode.h"
+#include "WebP/decode.h"
 
 static void free_data(void *info, const void *data, size_t size)
 {


### PR DESCRIPTION
Changed 'webp' to 'WebP' in the include path as it did not work in Xcode 8.